### PR TITLE
Write tar files to a stream instead of to the filesystem first

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*]
+indent_style=space
+indent_size=2
+

--- a/index.min.js
+++ b/index.min.js
@@ -4,133 +4,149 @@ function error(err) {
     err && logger(err.message);
 }
 
-function writeMetadata(documentStore) {
-    return function(collection, metadata, next) {
-        return collection.indexes(function(err, indexes) {
+function writeMetadata(collection, metadata, next) {
+    return collection.indexes(function(err, indexes) {
+        if (err) return next(err);
+        fs.writeFile(metadata + collection.collectionName, JSON.stringify(indexes), next);
+    });
+}
+
+function makeDir(pathname, next) {
+    fs.stat(pathname, function(err, stats) {
+        return err && "ENOENT" === err.code ? (logger("make dir at " + pathname), fs.mkdir(pathname, function(err) {
+            next(err, pathname);
+        })) : stats && !1 === stats.isDirectory() ? (logger("unlink file at " + pathname), 
+        fs.unlink(pathname, function(err) {
             if (err) return next(err);
-            documentStore.store(".metadata", collection.collectionName, JSON.stringify(indexes), next);
-        });
-    };
+            logger("make dir at " + pathname), fs.mkdir(pathname, function(err) {
+                next(err, pathname);
+            });
+        })) : void next(null, pathname);
+    });
 }
 
-function toJsonAsync(documentStore) {
-    return function(doc, collectionPath) {
-        documentStore.store(collectionPath, doc._id + ".json", JSON.stringify(doc));
-    };
+function rmDir(pathname, next) {
+    fs.readdirSync(pathname).forEach(function(first) {
+        var database = pathname + first;
+        if (!1 === fs.statSync(database).isDirectory()) return next(Error("path is not a Directory"));
+        var metadata = "", collections = fs.readdirSync(database), metadataPath = path.join(database, ".metadata");
+        return !0 === fs.existsSync(metadataPath) && (metadata = metadataPath + path.sep, 
+        delete collections[collections.indexOf(".metadata")]), collections.forEach(function(second) {
+            var collection = path.join(database, second);
+            !1 !== fs.statSync(collection).isDirectory() && (fs.readdirSync(collection).forEach(function(third) {
+                var document = path.join(collection, third);
+                return fs.unlinkSync(document), next ? next(null, document) : "";
+            }), "" !== metadata && fs.unlinkSync(metadata + second), fs.rmdirSync(collection));
+        }), "" !== metadata && fs.rmdirSync(metadata), fs.rmdirSync(database);
+    });
 }
 
-function toBsonAsync(documentStore) {
-    return function(doc, collectionPath) {
-        documentStore.store(collectionPath, doc._id + ".bson", BSON.serialize(doc));
-    };
+function toJsonAsync(doc, collectionPath) {
+    fs.writeFile(collectionPath + doc._id + ".json", JSON.stringify(doc));
 }
 
-function allCollections(documentStore) {
-    return function(db, name, query, metadata, parser, next) {
-        return db.collections(function(err, collections) {
-            if (err) return next(err);
-            var last = ~~collections.length, index = 0;
-            if (0 === last) return next(err);
-            collections.forEach(function(collection) {
-                if (!0 === systemRegex.test(collection.collectionName)) return last === ++index ? next(null) : null;
-                logger("select collection " + collection.collectionName), documentStore.addCollection(collection.collectionName, function(err) {
-                    if (err) return last === ++index ? next(err) : error(err);
-                    meta(collection, metadata, function() {
-                        collection.find(query).snapshot(!0).stream().once("end", function() {
-                            return last === ++index ? next(null) : null;
-                        }).on("data", function(doc) {
-                            parser(doc, collection.collectionName);
-                        });
+function toBsonAsync(doc, collectionPath) {
+    fs.writeFile(collectionPath + doc._id + ".bson", BSON.serialize(doc));
+}
+
+function allCollections(db, name, query, metadata, parser, next) {
+    return db.collections(function(err, collections) {
+        if (err) return next(err);
+        var last = ~~collections.length, index = 0;
+        if (0 === last) return next(err);
+        collections.forEach(function(collection) {
+            if (!0 === systemRegex.test(collection.collectionName)) return last === ++index ? next(null) : null;
+            logger("select collection " + collection.collectionName), makeDir(name + collection.collectionName + path.sep, function(err, name) {
+                if (err) return last === ++index ? next(err) : error(err);
+                meta(collection, metadata, function() {
+                    collection.find(query).snapshot(!0).stream().once("end", function() {
+                        return last === ++index ? next(null) : null;
+                    }).on("data", function(doc) {
+                        parser(doc, name);
                     });
                 });
             });
         });
-    };
+    });
 }
 
-function allCollectionsScan(documentStore) {
-    return function(db, name, numCursors, metadata, parser, next) {
-        return db.collections(function(err, collections) {
-            if (err) return next(err);
-            var last = ~~collections.length, index = 0;
-            if (0 === last) return next(null);
-            collections.forEach(function(collection) {
-                if (!0 === systemRegex.test(collection.collectionName)) return last === ++index ? next(null) : null;
-                logger("select collection scan " + collection.collectionName), documentStore.addCollection(collection.collectionName, function(err) {
-                    if (err) return last === ++index ? next(err) : error(err);
-                    meta(collection, metadata, function() {
-                        collection.parallelCollectionScan({
-                            numCursors: numCursors
-                        }, function(err, cursors) {
-                            if (err) return last === ++index ? next(err) : error(err);
-                            var ii, cursorsDone;
-                            if (0 === (ii = cursorsDone = ~~cursors.length)) return last === ++index ? next(null) : null;
-                            for (var i = 0; i < ii; ++i) cursors[i].once("end", function() {
-                                if (0 == --cursorsDone) return last === ++index ? next(null) : null;
-                            }).on("data", function(doc) {
-                                parser(doc, collection.collectionName);
-                            });
-                        });
-                    });
-                });
-            });
-        });
-    };
-}
-
-function someCollections(documentStore) {
-    return function(db, name, query, metadata, parser, next, collections) {
+function allCollectionsScan(db, name, numCursors, metadata, parser, next) {
+    return db.collections(function(err, collections) {
+        if (err) return next(err);
         var last = ~~collections.length, index = 0;
         if (0 === last) return next(null);
         collections.forEach(function(collection) {
-            db.collection(collection, {
-                strict: !0
-            }, function(err, collection) {
+            if (!0 === systemRegex.test(collection.collectionName)) return last === ++index ? next(null) : null;
+            logger("select collection scan " + collection.collectionName), makeDir(name + collection.collectionName + path.sep, function(err, name) {
                 if (err) return last === ++index ? next(err) : error(err);
-                logger("select collection " + collection.collectionName), documentStore.addCollection(collection.collectionName, function(err) {
-                    if (err) return last === ++index ? next(err) : error(err);
-                    meta(collection, metadata, function() {
-                        collection.find(query).snapshot(!0).stream().once("end", function() {
-                            return last === ++index ? next(null) : null;
+                meta(collection, metadata, function() {
+                    collection.parallelCollectionScan({
+                        numCursors: numCursors
+                    }, function(err, cursors) {
+                        if (err) return last === ++index ? next(err) : error(err);
+                        var ii, cursorsDone;
+                        if (0 === (ii = cursorsDone = ~~cursors.length)) return last === ++index ? next(null) : null;
+                        for (var i = 0; i < ii; ++i) cursors[i].once("end", function() {
+                            if (0 == --cursorsDone) return last === ++index ? next(null) : null;
                         }).on("data", function(doc) {
-                            parser(doc, collection.collectionName);
+                            parser(doc, name);
                         });
                     });
                 });
             });
         });
-    };
+    });
 }
 
-function someCollectionsScan(documentStore) {
-    return function(db, name, numCursors, metadata, parser, next, collections) {
-        var last = ~~collections.length, index = 0;
-        if (0 === last) return next(null);
-        collections.forEach(function(collection) {
-            db.collection(collection, {
-                strict: !0
-            }, function(err, collection) {
+function someCollections(db, name, query, metadata, parser, next, collections) {
+    var last = ~~collections.length, index = 0;
+    if (0 === last) return next(null);
+    collections.forEach(function(collection) {
+        db.collection(collection, {
+            strict: !0
+        }, function(err, collection) {
+            if (err) return last === ++index ? next(err) : error(err);
+            logger("select collection " + collection.collectionName), makeDir(name + collection.collectionName + path.sep, function(err, name) {
                 if (err) return last === ++index ? next(err) : error(err);
-                logger("select collection scan " + collection.collectionName), documentStore.addCollection(collection.collectionName, function(err) {
-                    if (err) return last === ++index ? next(err) : error(err);
-                    meta(collection, metadata, function() {
-                        collection.parallelCollectionScan({
-                            numCursors: numCursors
-                        }, function(err, cursors) {
-                            if (err) return last === ++index ? next(err) : error(err);
-                            var ii, cursorsDone;
-                            if (0 === (ii = cursorsDone = ~~cursors.length)) return last === ++index ? next(null) : null;
-                            for (var i = 0; i < ii; ++i) cursors[i].once("end", function() {
-                                if (0 == --cursorsDone) return last === ++index ? next(null) : null;
-                            }).on("data", function(doc) {
-                                parser(doc, collection.collectionName);
-                            });
+                meta(collection, metadata, function() {
+                    collection.find(query).snapshot(!0).stream().once("end", function() {
+                        return last === ++index ? next(null) : null;
+                    }).on("data", function(doc) {
+                        parser(doc, name);
+                    });
+                });
+            });
+        });
+    });
+}
+
+function someCollectionsScan(db, name, numCursors, metadata, parser, next, collections) {
+    var last = ~~collections.length, index = 0;
+    if (0 === last) return next(null);
+    collections.forEach(function(collection) {
+        db.collection(collection, {
+            strict: !0
+        }, function(err, collection) {
+            if (err) return last === ++index ? next(err) : error(err);
+            logger("select collection scan " + collection.collectionName), makeDir(name + collection.collectionName + path.sep, function(err, name) {
+                if (err) return last === ++index ? next(err) : error(err);
+                meta(collection, metadata, function() {
+                    collection.parallelCollectionScan({
+                        numCursors: numCursors
+                    }, function(err, cursors) {
+                        if (err) return last === ++index ? next(err) : error(err);
+                        var ii, cursorsDone;
+                        if (0 === (ii = cursorsDone = ~~cursors.length)) return last === ++index ? next(null) : null;
+                        for (var i = 0; i < ii; ++i) cursors[i].once("end", function() {
+                            if (0 == --cursorsDone) return last === ++index ? next(null) : null;
+                        }).on("data", function(doc) {
+                            parser(doc, name);
                         });
                     });
                 });
             });
         });
-    };
+    });
 }
 
 function wrapper(my) {
@@ -140,19 +156,19 @@ function wrapper(my) {
     var parser;
     if ("function" == typeof my.parser) parser = my.parser; else switch (my.parser.toLowerCase()) {
       case "bson":
-        BSON = require("bson"), BSON = new BSON(), parser = toBsonAsync(my.documentStore);
+        BSON = require("bson"), BSON = new BSON(), parser = toBsonAsync;
         break;
 
       case "json":
-        parser = toJsonAsync(my.documentStore);
+        parser = toJsonAsync;
         break;
 
       default:
         throw new Error("missing parser option");
     }
-    var discriminator = allCollections(my.documentStore);
-    if (null !== my.collections ? (discriminator = someCollections(my.documentStore), 
-    my.numCursors && (discriminator = someCollectionsScan(my.documentStore), my.query = my.numCursors)) : my.numCursors && (discriminator = allCollectionsScan(my.documentStore), 
+    var discriminator = allCollections;
+    if (null !== my.collections ? (discriminator = someCollections, my.numCursors && (discriminator = someCollectionsScan, 
+    my.query = my.numCursors)) : my.numCursors && (discriminator = allCollectionsScan, 
     my.query = my.numCursors), null === my.logger) logger = function() {}; else {
         (logger = require("logger-request")({
             filename: my.logger,
@@ -170,19 +186,35 @@ function wrapper(my) {
         });
     }
     var metadata = "";
-    meta = !0 === my.metadata ? writeMetadata(my.documentStore) : function(a, b, c) {
+    meta = !0 === my.metadata ? writeMetadata : function(a, b, c) {
         return c();
     }, require("mongodb").MongoClient.connect(my.uri, my.options, function(err, db) {
         if (logger("db open"), err) return callback(err);
-        my.documentStore.addDatabase(db.databaseName, function(err, name) {
-            function go() {
-                return discriminator(db, name, my.query, metadata, parser, function(err) {
-                    if (logger("db close"), db.close(), err) return callback(err);
-                    my.documentStore.close(), callback(null);
-                }, my.collections);
-            }
+        var root = null === my.tar ? my.root : my.dir;
+        makeDir(root, function(err, name) {
             if (err) return callback(err);
-            !1 === my.metadata ? go() : my.documentStore.addCollection(".metadata", go);
+            makeDir(name + db.databaseName + path.sep, function(err, name) {
+                function go() {
+                    return discriminator(db, name, my.query, metadata, parser, function(err) {
+                        if (logger("db close"), db.close(), err) return callback(err);
+                        my.tar ? makeDir(my.root, function(e, name) {
+                            err && error(err);
+                            var dest;
+                            my.stream ? (logger("send tar file to stream"), dest = my.stream) : (logger("make tar file at " + name + my.tar), 
+                            dest = fs.createWriteStream(name + my.tar));
+                            var packer = require("tar").Pack().on("error", callback).on("end", function() {
+                                rmDir(root), callback(null);
+                            });
+                            require("fstream").Reader({
+                                path: root + db.databaseName,
+                                type: "Directory"
+                            }).on("error", callback).pipe(packer).pipe(dest);
+                        }) : callback(null);
+                    }, my.collections);
+                }
+                if (err) return callback(err);
+                !1 === my.metadata ? go() : makeDir(metadata = name + ".metadata" + path.sep, go);
+            });
         });
     });
 }
@@ -195,6 +227,7 @@ function backup(options) {
         if (fs.existsSync(opt.root) && !fs.statSync(opt.root).isDirectory()) throw new Error("root option is not a directory");
     }
     var my = {
+        dir: path.join(__dirname, "dump", path.sep),
         uri: String(opt.uri),
         root: path.resolve(String(opt.root || "")) + path.sep,
         stream: opt.stream || null,
@@ -208,64 +241,9 @@ function backup(options) {
         options: "object" == typeof opt.options ? opt.options : {},
         metadata: Boolean(opt.metadata)
     };
-    return my.tar && !my.stream && (my.stream = fs.createWriteStream(path.join(my.root, my.tar))), 
-    my.stream ? (my.tar = !0, my.documentStore = streamingDocumentStore(my.root, my.stream)) : my.documentStore = fileSystemDocumentStore(my.root), 
-    wrapper(my);
+    return my.stream && (my.tar = !0), wrapper(my);
 }
 
-var systemRegex = /^system\./, fs = require("graceful-fs").gracefulify(require("fs-extra")), path = require("path"), BSON, logger, meta, fileSystemDocumentStore = function(root) {
-    var dbDir = root, makeDir = function(pathname, next) {
-        fs.stat(pathname, function(err, stats) {
-            return err && "ENOENT" === err.code ? (logger("make dir at " + pathname), fs.mkdirp(pathname, function(err) {
-                next(err, pathname);
-            })) : stats && !1 === stats.isDirectory() ? (logger("unlink file at " + pathname), 
-            fs.unlink(pathname, function(err) {
-                if (err) return next(err);
-                logger("make dir at " + pathname), fs.mkdir(pathname, function(err) {
-                    next(err, pathname);
-                });
-            })) : void next(null, pathname);
-        });
-    };
-    return {
-        addDatabase: function(dbName, next) {
-            return dbDir = path.join(root, dbName), makeDir(dbDir, next);
-        },
-        addCollection: function(relativePath, next) {
-            var pathname = path.join(dbDir, relativePath);
-            return makeDir(pathname, next);
-        },
-        store: function(collectionName, relativePath, content, callback) {
-            fs.writeFile(path.join(dbDir, collectionName, relativePath), content, callback);
-        },
-        close: function() {}
-    };
-}, streamingDocumentStore = function(root, stream) {
-    var pack = require("tar-stream").pack();
-    pack.pipe(stream);
-    var dbDir = root;
-    return {
-        addDatabase: function(dbName, next) {
-            dbDir = path.join(root, dbName), pack.entry({
-                name: dbDir,
-                type: "directory"
-            }), next();
-        },
-        addCollection: function(filename, next) {
-            "" !== filename && pack.entry({
-                name: path.join(dbDir, filename),
-                type: "directory"
-            }), next();
-        },
-        store: function(collectionName, filename, content, callback) {
-            pack.entry({
-                name: path.join(dbDir, collectionName, filename)
-            }, content), callback && callback();
-        },
-        close: function() {
-            pack.finalize();
-        }
-    };
-};
+var systemRegex = /^system\./, fs = require("graceful-fs"), path = require("path"), BSON, logger, meta;
 
 module.exports = backup;

--- a/index.min.js
+++ b/index.min.js
@@ -4,149 +4,133 @@ function error(err) {
     err && logger(err.message);
 }
 
-function writeMetadata(collection, metadata, next) {
-    return collection.indexes(function(err, indexes) {
-        if (err) return next(err);
-        fs.writeFile(metadata + collection.collectionName, JSON.stringify(indexes), next);
-    });
-}
-
-function makeDir(pathname, next) {
-    fs.stat(pathname, function(err, stats) {
-        return err && "ENOENT" === err.code ? (logger("make dir at " + pathname), fs.mkdir(pathname, function(err) {
-            next(err, pathname);
-        })) : stats && !1 === stats.isDirectory() ? (logger("unlink file at " + pathname), 
-        fs.unlink(pathname, function(err) {
+function writeMetadata(documentStore) {
+    return function(collection, metadata, next) {
+        return collection.indexes(function(err, indexes) {
             if (err) return next(err);
-            logger("make dir at " + pathname), fs.mkdir(pathname, function(err) {
-                next(err, pathname);
-            });
-        })) : void next(null, pathname);
-    });
+            documentStore.store(".metadata", collection.collectionName, JSON.stringify(indexes), next);
+        });
+    };
 }
 
-function rmDir(pathname, next) {
-    fs.readdirSync(pathname).forEach(function(first) {
-        var database = pathname + first;
-        if (!1 === fs.statSync(database).isDirectory()) return next(Error("path is not a Directory"));
-        var metadata = "", collections = fs.readdirSync(database), metadataPath = path.join(database, ".metadata");
-        return !0 === fs.existsSync(metadataPath) && (metadata = metadataPath + path.sep, 
-        delete collections[collections.indexOf(".metadata")]), collections.forEach(function(second) {
-            var collection = path.join(database, second);
-            !1 !== fs.statSync(collection).isDirectory() && (fs.readdirSync(collection).forEach(function(third) {
-                var document = path.join(collection, third);
-                return fs.unlinkSync(document), next ? next(null, document) : "";
-            }), "" !== metadata && fs.unlinkSync(metadata + second), fs.rmdirSync(collection));
-        }), "" !== metadata && fs.rmdirSync(metadata), fs.rmdirSync(database);
-    });
+function toJsonAsync(documentStore) {
+    return function(doc, collectionPath) {
+        documentStore.store(collectionPath, doc._id + ".json", JSON.stringify(doc));
+    };
 }
 
-function toJsonAsync(doc, collectionPath) {
-    fs.writeFile(collectionPath + doc._id + ".json", JSON.stringify(doc));
+function toBsonAsync(documentStore) {
+    return function(doc, collectionPath) {
+        documentStore.store(collectionPath, doc._id + ".bson", BSON.serialize(doc));
+    };
 }
 
-function toBsonAsync(doc, collectionPath) {
-    fs.writeFile(collectionPath + doc._id + ".bson", BSON.serialize(doc));
-}
-
-function allCollections(db, name, query, metadata, parser, next) {
-    return db.collections(function(err, collections) {
-        if (err) return next(err);
-        var last = ~~collections.length, index = 0;
-        if (0 === last) return next(err);
-        collections.forEach(function(collection) {
-            if (!0 === systemRegex.test(collection.collectionName)) return last === ++index ? next(null) : null;
-            logger("select collection " + collection.collectionName), makeDir(name + collection.collectionName + path.sep, function(err, name) {
-                if (err) return last === ++index ? next(err) : error(err);
-                meta(collection, metadata, function() {
-                    collection.find(query).snapshot(!0).stream().once("end", function() {
-                        return last === ++index ? next(null) : null;
-                    }).on("data", function(doc) {
-                        parser(doc, name);
+function allCollections(documentStore) {
+    return function(db, name, query, metadata, parser, next) {
+        return db.collections(function(err, collections) {
+            if (err) return next(err);
+            var last = ~~collections.length, index = 0;
+            if (0 === last) return next(err);
+            collections.forEach(function(collection) {
+                if (!0 === systemRegex.test(collection.collectionName)) return last === ++index ? next(null) : null;
+                logger("select collection " + collection.collectionName), documentStore.addCollection(collection.collectionName, function(err) {
+                    if (err) return last === ++index ? next(err) : error(err);
+                    meta(collection, metadata, function() {
+                        collection.find(query).snapshot(!0).stream().once("end", function() {
+                            return last === ++index ? next(null) : null;
+                        }).on("data", function(doc) {
+                            parser(doc, collection.collectionName);
+                        });
                     });
                 });
             });
         });
-    });
+    };
 }
 
-function allCollectionsScan(db, name, numCursors, metadata, parser, next) {
-    return db.collections(function(err, collections) {
-        if (err) return next(err);
+function allCollectionsScan(documentStore) {
+    return function(db, name, numCursors, metadata, parser, next) {
+        return db.collections(function(err, collections) {
+            if (err) return next(err);
+            var last = ~~collections.length, index = 0;
+            if (0 === last) return next(null);
+            collections.forEach(function(collection) {
+                if (!0 === systemRegex.test(collection.collectionName)) return last === ++index ? next(null) : null;
+                logger("select collection scan " + collection.collectionName), documentStore.addCollection(collection.collectionName, function(err) {
+                    if (err) return last === ++index ? next(err) : error(err);
+                    meta(collection, metadata, function() {
+                        collection.parallelCollectionScan({
+                            numCursors: numCursors
+                        }, function(err, cursors) {
+                            if (err) return last === ++index ? next(err) : error(err);
+                            var ii, cursorsDone;
+                            if (0 === (ii = cursorsDone = ~~cursors.length)) return last === ++index ? next(null) : null;
+                            for (var i = 0; i < ii; ++i) cursors[i].once("end", function() {
+                                if (0 == --cursorsDone) return last === ++index ? next(null) : null;
+                            }).on("data", function(doc) {
+                                parser(doc, collection.collectionName);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    };
+}
+
+function someCollections(documentStore) {
+    return function(db, name, query, metadata, parser, next, collections) {
         var last = ~~collections.length, index = 0;
         if (0 === last) return next(null);
         collections.forEach(function(collection) {
-            if (!0 === systemRegex.test(collection.collectionName)) return last === ++index ? next(null) : null;
-            logger("select collection scan " + collection.collectionName), makeDir(name + collection.collectionName + path.sep, function(err, name) {
+            db.collection(collection, {
+                strict: !0
+            }, function(err, collection) {
                 if (err) return last === ++index ? next(err) : error(err);
-                meta(collection, metadata, function() {
-                    collection.parallelCollectionScan({
-                        numCursors: numCursors
-                    }, function(err, cursors) {
-                        if (err) return last === ++index ? next(err) : error(err);
-                        var ii, cursorsDone;
-                        if (0 === (ii = cursorsDone = ~~cursors.length)) return last === ++index ? next(null) : null;
-                        for (var i = 0; i < ii; ++i) cursors[i].once("end", function() {
-                            if (0 == --cursorsDone) return last === ++index ? next(null) : null;
+                logger("select collection " + collection.collectionName), documentStore.addCollection(collection.collectionName, function(err) {
+                    if (err) return last === ++index ? next(err) : error(err);
+                    meta(collection, metadata, function() {
+                        collection.find(query).snapshot(!0).stream().once("end", function() {
+                            return last === ++index ? next(null) : null;
                         }).on("data", function(doc) {
-                            parser(doc, name);
+                            parser(doc, collection.collectionName);
                         });
                     });
                 });
             });
         });
-    });
+    };
 }
 
-function someCollections(db, name, query, metadata, parser, next, collections) {
-    var last = ~~collections.length, index = 0;
-    if (0 === last) return next(null);
-    collections.forEach(function(collection) {
-        db.collection(collection, {
-            strict: !0
-        }, function(err, collection) {
-            if (err) return last === ++index ? next(err) : error(err);
-            logger("select collection " + collection.collectionName), makeDir(name + collection.collectionName + path.sep, function(err, name) {
+function someCollectionsScan(documentStore) {
+    return function(db, name, numCursors, metadata, parser, next, collections) {
+        var last = ~~collections.length, index = 0;
+        if (0 === last) return next(null);
+        collections.forEach(function(collection) {
+            db.collection(collection, {
+                strict: !0
+            }, function(err, collection) {
                 if (err) return last === ++index ? next(err) : error(err);
-                meta(collection, metadata, function() {
-                    collection.find(query).snapshot(!0).stream().once("end", function() {
-                        return last === ++index ? next(null) : null;
-                    }).on("data", function(doc) {
-                        parser(doc, name);
-                    });
-                });
-            });
-        });
-    });
-}
-
-function someCollectionsScan(db, name, numCursors, metadata, parser, next, collections) {
-    var last = ~~collections.length, index = 0;
-    if (0 === last) return next(null);
-    collections.forEach(function(collection) {
-        db.collection(collection, {
-            strict: !0
-        }, function(err, collection) {
-            if (err) return last === ++index ? next(err) : error(err);
-            logger("select collection scan " + collection.collectionName), makeDir(name + collection.collectionName + path.sep, function(err, name) {
-                if (err) return last === ++index ? next(err) : error(err);
-                meta(collection, metadata, function() {
-                    collection.parallelCollectionScan({
-                        numCursors: numCursors
-                    }, function(err, cursors) {
-                        if (err) return last === ++index ? next(err) : error(err);
-                        var ii, cursorsDone;
-                        if (0 === (ii = cursorsDone = ~~cursors.length)) return last === ++index ? next(null) : null;
-                        for (var i = 0; i < ii; ++i) cursors[i].once("end", function() {
-                            if (0 == --cursorsDone) return last === ++index ? next(null) : null;
-                        }).on("data", function(doc) {
-                            parser(doc, name);
+                logger("select collection scan " + collection.collectionName), documentStore.addCollection(collection.collectionName, function(err) {
+                    if (err) return last === ++index ? next(err) : error(err);
+                    meta(collection, metadata, function() {
+                        collection.parallelCollectionScan({
+                            numCursors: numCursors
+                        }, function(err, cursors) {
+                            if (err) return last === ++index ? next(err) : error(err);
+                            var ii, cursorsDone;
+                            if (0 === (ii = cursorsDone = ~~cursors.length)) return last === ++index ? next(null) : null;
+                            for (var i = 0; i < ii; ++i) cursors[i].once("end", function() {
+                                if (0 == --cursorsDone) return last === ++index ? next(null) : null;
+                            }).on("data", function(doc) {
+                                parser(doc, collection.collectionName);
+                            });
                         });
                     });
                 });
             });
         });
-    });
+    };
 }
 
 function wrapper(my) {
@@ -156,19 +140,19 @@ function wrapper(my) {
     var parser;
     if ("function" == typeof my.parser) parser = my.parser; else switch (my.parser.toLowerCase()) {
       case "bson":
-        BSON = require("bson"), BSON = new BSON(), parser = toBsonAsync;
+        BSON = require("bson"), BSON = new BSON(), parser = toBsonAsync(my.documentStore);
         break;
 
       case "json":
-        parser = toJsonAsync;
+        parser = toJsonAsync(my.documentStore);
         break;
 
       default:
         throw new Error("missing parser option");
     }
-    var discriminator = allCollections;
-    if (null !== my.collections ? (discriminator = someCollections, my.numCursors && (discriminator = someCollectionsScan, 
-    my.query = my.numCursors)) : my.numCursors && (discriminator = allCollectionsScan, 
+    var discriminator = allCollections(my.documentStore);
+    if (null !== my.collections ? (discriminator = someCollections(my.documentStore), 
+    my.numCursors && (discriminator = someCollectionsScan(my.documentStore), my.query = my.numCursors)) : my.numCursors && (discriminator = allCollectionsScan(my.documentStore), 
     my.query = my.numCursors), null === my.logger) logger = function() {}; else {
         (logger = require("logger-request")({
             filename: my.logger,
@@ -186,35 +170,19 @@ function wrapper(my) {
         });
     }
     var metadata = "";
-    meta = !0 === my.metadata ? writeMetadata : function(a, b, c) {
+    meta = !0 === my.metadata ? writeMetadata(my.documentStore) : function(a, b, c) {
         return c();
     }, require("mongodb").MongoClient.connect(my.uri, my.options, function(err, db) {
         if (logger("db open"), err) return callback(err);
-        var root = null === my.tar ? my.root : my.dir;
-        makeDir(root, function(err, name) {
+        my.documentStore.addDatabase(db.databaseName, function(err, name) {
+            function go() {
+                return discriminator(db, name, my.query, metadata, parser, function(err) {
+                    if (logger("db close"), db.close(), err) return callback(err);
+                    my.documentStore.close(), callback(null);
+                }, my.collections);
+            }
             if (err) return callback(err);
-            makeDir(name + db.databaseName + path.sep, function(err, name) {
-                function go() {
-                    return discriminator(db, name, my.query, metadata, parser, function(err) {
-                        if (logger("db close"), db.close(), err) return callback(err);
-                        my.tar ? makeDir(my.root, function(e, name) {
-                            err && error(err);
-                            var dest;
-                            my.stream ? (logger("send tar file to stream"), dest = my.stream) : (logger("make tar file at " + name + my.tar), 
-                            dest = fs.createWriteStream(name + my.tar));
-                            var packer = require("tar").Pack().on("error", callback).on("end", function() {
-                                rmDir(root), callback(null);
-                            });
-                            require("fstream").Reader({
-                                path: root + db.databaseName,
-                                type: "Directory"
-                            }).on("error", callback).pipe(packer).pipe(dest);
-                        }) : callback(null);
-                    }, my.collections);
-                }
-                if (err) return callback(err);
-                !1 === my.metadata ? go() : makeDir(metadata = name + ".metadata" + path.sep, go);
-            });
+            !1 === my.metadata ? go() : my.documentStore.addCollection(".metadata", go);
         });
     });
 }
@@ -227,7 +195,6 @@ function backup(options) {
         if (fs.existsSync(opt.root) && !fs.statSync(opt.root).isDirectory()) throw new Error("root option is not a directory");
     }
     var my = {
-        dir: path.join(__dirname, "dump", path.sep),
         uri: String(opt.uri),
         root: path.resolve(String(opt.root || "")) + path.sep,
         stream: opt.stream || null,
@@ -241,9 +208,64 @@ function backup(options) {
         options: "object" == typeof opt.options ? opt.options : {},
         metadata: Boolean(opt.metadata)
     };
-    return my.stream && (my.tar = !0), wrapper(my);
+    return my.tar && !my.stream && (my.stream = fs.createWriteStream(path.join(my.root, my.tar))), 
+    my.stream ? (my.tar = !0, my.documentStore = streamingDocumentStore(my.root, my.stream)) : my.documentStore = fileSystemDocumentStore(my.root), 
+    wrapper(my);
 }
 
-var systemRegex = /^system\./, fs = require("graceful-fs"), path = require("path"), BSON, logger, meta;
+var systemRegex = /^system\./, fs = require("graceful-fs").gracefulify(require("fs-extra")), path = require("path"), BSON, logger, meta, fileSystemDocumentStore = function(root) {
+    var dbDir = root, makeDir = function(pathname, next) {
+        fs.stat(pathname, function(err, stats) {
+            return err && "ENOENT" === err.code ? (logger("make dir at " + pathname), fs.mkdirp(pathname, function(err) {
+                next(err, pathname);
+            })) : stats && !1 === stats.isDirectory() ? (logger("unlink file at " + pathname), 
+            fs.unlink(pathname, function(err) {
+                if (err) return next(err);
+                logger("make dir at " + pathname), fs.mkdir(pathname, function(err) {
+                    next(err, pathname);
+                });
+            })) : void next(null, pathname);
+        });
+    };
+    return {
+        addDatabase: function(dbName, next) {
+            return dbDir = path.join(root, dbName), makeDir(dbDir, next);
+        },
+        addCollection: function(relativePath, next) {
+            var pathname = path.join(dbDir, relativePath);
+            return makeDir(pathname, next);
+        },
+        store: function(collectionName, relativePath, content, callback) {
+            fs.writeFile(path.join(dbDir, collectionName, relativePath), content, callback);
+        },
+        close: function() {}
+    };
+}, streamingDocumentStore = function(root, stream) {
+    var pack = require("tar-stream").pack();
+    pack.pipe(stream);
+    var dbDir = root;
+    return {
+        addDatabase: function(dbName, next) {
+            dbDir = path.join(root, dbName), pack.entry({
+                name: dbDir,
+                type: "directory"
+            }), next();
+        },
+        addCollection: function(filename, next) {
+            "" !== filename && pack.entry({
+                name: path.join(dbDir, filename),
+                type: "directory"
+            }), next();
+        },
+        store: function(collectionName, filename, content, callback) {
+            pack.entry({
+                name: path.join(dbDir, collectionName, filename)
+            }, content), callback && callback();
+        },
+        close: function() {
+            pack.finalize();
+        }
+    };
+};
 
 module.exports = backup;

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
   "main": "index.min.js",
   "dependencies": {
     "bson": "1.0.4",
+    "fs-extra": "^3.0.1",
     "fstream": "1.0.11",
     "graceful-fs": "4.1.11",
     "logger-request": "3.8.0",
     "mongodb": "2.2.26",
-    "tar": "2.2.1"
+    "tar-stream": "^1.5.4"
   },
   "devDependencies": {
     "grunt": "~1.0",


### PR DESCRIPTION
This improves performance when writing to a stream (i.e. there is no need to wait for the contents to be written to disk first), and can help solve EMFILE errors. This is achieved by using tar-stream instead of regular tar.

This commit introduces a small shim in front of the file system and tar-stream to allow both direct disk writes and tar file stream writes. It then uses the appropriate shim (file system or tar-stream) throughout the codebase to create directories and store files.

Potentially fixes #20.